### PR TITLE
Plugin issue with multiple panels

### DIFF
--- a/src/FilamentDeveloperLoginsServiceProvider.php
+++ b/src/FilamentDeveloperLoginsServiceProvider.php
@@ -4,6 +4,7 @@ namespace DutchCodingCompany\FilamentDeveloperLogins;
 
 use DutchCodingCompany\FilamentDeveloperLogins\Livewire\MenuLogins;
 use DutchCodingCompany\FilamentDeveloperLogins\View\Components\DeveloperLogins;
+use Filament\Panel;
 use Filament\Facades\Filament;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\Facades\FilamentView;
@@ -45,7 +46,8 @@ class FilamentDeveloperLoginsServiceProvider extends PackageServiceProvider
     protected static function registerRenderHooks(): void
     {
         $panel = Filament::getCurrentPanel();
-        if (is_null($panel) || ! $panel->hasPlugin('filament-developer-logins')) {
+
+        if(! self::enabledForPanel($panel)) {
             return;
         }
 
@@ -55,7 +57,8 @@ class FilamentDeveloperLoginsServiceProvider extends PackageServiceProvider
         FilamentView::registerRenderHook(
             PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
             static function () use ($plugin) : ?string {
-                if (! $plugin->getEnabled()) {
+
+                if (! $plugin->getEnabled() || ! self::enabledForPanel(Filament::getCurrentPanel())) {
                     return null;
                 }
 
@@ -66,12 +69,17 @@ class FilamentDeveloperLoginsServiceProvider extends PackageServiceProvider
         FilamentView::registerRenderHook(
             PanelsRenderHook::GLOBAL_SEARCH_AFTER,
             static function () use ($plugin) : ?string {
-                if (! $plugin->getEnabled() || ! $plugin->getSwitchable()) {
+                if (! $plugin->getEnabled() || ! $plugin->getSwitchable() || ! self::enabledForPanel(Filament::getCurrentPanel())) {
                     return null;
                 }
 
                 return Blade::render('@livewire(\'menu-logins\')');
             },
         );
+    }
+
+    protected static function enabledForPanel(?Panel $panel)
+    {
+        return ! is_null($panel) && $panel->hasPlugin('filament-developer-logins');
     }
 }

--- a/src/FilamentDeveloperLoginsServiceProvider.php
+++ b/src/FilamentDeveloperLoginsServiceProvider.php
@@ -4,8 +4,8 @@ namespace DutchCodingCompany\FilamentDeveloperLogins;
 
 use DutchCodingCompany\FilamentDeveloperLogins\Livewire\MenuLogins;
 use DutchCodingCompany\FilamentDeveloperLogins\View\Components\DeveloperLogins;
-use Filament\Panel;
 use Filament\Facades\Filament;
+use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
@@ -45,20 +45,17 @@ class FilamentDeveloperLoginsServiceProvider extends PackageServiceProvider
 
     protected static function registerRenderHooks(): void
     {
-        $panel = Filament::getCurrentPanel();
-
-        if(! self::enabledForPanel($panel)) {
-            return;
-        }
-
-        /** @var FilamentDeveloperLoginsPlugin $plugin */
-        $plugin = $panel->getPlugin('filament-developer-logins');
-
         FilamentView::registerRenderHook(
             PanelsRenderHook::AUTH_LOGIN_FORM_AFTER,
-            static function () use ($plugin) : ?string {
+            static function (): ?string {
+                $panel = Filament::getCurrentPanel();
+                if (! self::panelHasPlugin($panel)) {
+                    return null;
+                }
 
-                if (! $plugin->getEnabled() || ! self::enabledForPanel(Filament::getCurrentPanel())) {
+                /** @var FilamentDeveloperLoginsPlugin $plugin */
+                $plugin = $panel->getPlugin('filament-developer-logins');
+                if (! $plugin->getEnabled()) {
                     return null;
                 }
 
@@ -68,8 +65,15 @@ class FilamentDeveloperLoginsServiceProvider extends PackageServiceProvider
 
         FilamentView::registerRenderHook(
             PanelsRenderHook::GLOBAL_SEARCH_AFTER,
-            static function () use ($plugin) : ?string {
-                if (! $plugin->getEnabled() || ! $plugin->getSwitchable() || ! self::enabledForPanel(Filament::getCurrentPanel())) {
+            static function (): ?string {
+                $panel = Filament::getCurrentPanel();
+                if (! self::panelHasPlugin($panel)) {
+                    return null;
+                }
+
+                /** @var FilamentDeveloperLoginsPlugin $plugin */
+                $plugin = $panel->getPlugin('filament-developer-logins');
+                if (! $plugin->getEnabled() || ! $plugin->getSwitchable()) {
                     return null;
                 }
 
@@ -78,7 +82,7 @@ class FilamentDeveloperLoginsServiceProvider extends PackageServiceProvider
         );
     }
 
-    protected static function enabledForPanel(?Panel $panel)
+    protected static function panelHasPlugin(?Panel $panel): bool
     {
         return ! is_null($panel) && $panel->hasPlugin('filament-developer-logins');
     }

--- a/tests/Feature/MenuLoginsTest.php
+++ b/tests/Feature/MenuLoginsTest.php
@@ -84,7 +84,6 @@ final class MenuLoginsTest extends TestCase
 
     public function test_component_is_only_rendered_in_panel_with_plugin(): void
     {
-
         $user = TestUser::factory()->create();
 
         $this->actingAs($user)
@@ -92,28 +91,9 @@ final class MenuLoginsTest extends TestCase
             ->assertSuccessful()
             ->assertSeeLivewire(MenuLogins::class);
 
-
         $this->actingAs($user)
-            ->get(Dashboard::getUrl(panel: $this->panelName . '-other' ))
+            ->get(Dashboard::getUrl(panel: $this->panelName.'-other'))
             ->assertSuccessful()
             ->assertDontSeeLivewire(MenuLogins::class);
     }
-
-    protected function registerTestPanel(): void
-    {
-        parent::registerTestPanel();
-        Filament::registerPanel(fn() => Panel::make()
-            ->darkMode(false)
-            ->id($this->panelName . '-other')
-            ->path($this->panelName  . '-other')
-            ->login()
-            ->pages([
-                Dashboard::class,
-            ])
-            ->plugins([
-            ]),
-        );
-    }
-
-
 }

--- a/tests/Feature/MenuLoginsTest.php
+++ b/tests/Feature/MenuLoginsTest.php
@@ -8,6 +8,7 @@ use DutchCodingCompany\FilamentDeveloperLogins\Tests\Fixtures\TestUser;
 use DutchCodingCompany\FilamentDeveloperLogins\Tests\TestCase;
 use Filament\Facades\Filament;
 use Filament\Pages\Dashboard;
+use Filament\Panel;
 use Livewire\Livewire;
 
 final class MenuLoginsTest extends TestCase
@@ -80,4 +81,39 @@ final class MenuLoginsTest extends TestCase
             ->call('loginAs', 'developer@dutchcodingcompany.com')
             ->assertForbidden();
     }
+
+    public function test_component_is_only_rendered_in_panel_with_plugin(): void
+    {
+
+        $user = TestUser::factory()->create();
+
+        $this->actingAs($user)
+            ->get(Dashboard::getUrl(panel: $this->panelName))
+            ->assertSuccessful()
+            ->assertSeeLivewire(MenuLogins::class);
+
+
+        $this->actingAs($user)
+            ->get(Dashboard::getUrl(panel: $this->panelName . '-other' ))
+            ->assertSuccessful()
+            ->assertDontSeeLivewire(MenuLogins::class);
+    }
+
+    protected function registerTestPanel(): void
+    {
+        parent::registerTestPanel();
+        Filament::registerPanel(fn() => Panel::make()
+            ->darkMode(false)
+            ->id($this->panelName . '-other')
+            ->path($this->panelName  . '-other')
+            ->login()
+            ->pages([
+                Dashboard::class,
+            ])
+            ->plugins([
+            ]),
+        );
+    }
+
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,7 +36,7 @@ class TestCase extends Orchestra
         );
     }
 
-    protected function registerTestPanel(): void
+    protected function registerTestPanels(): void
     {
         Filament::registerPanel(
             fn (): Panel => Panel::make()
@@ -56,6 +56,18 @@ class TestCase extends Orchestra
                         ])
                         ->modelClass(TestUser::class),
                 ]),
+        );
+
+        Filament::registerPanel(fn () => Panel::make()
+            ->darkMode(false)
+            ->id($this->panelName.'-other')
+            ->path($this->panelName.'-other')
+            ->login()
+            ->pages([
+                Dashboard::class,
+            ])
+            ->plugins([
+            ]),
         );
     }
 
@@ -80,7 +92,7 @@ class TestCase extends Orchestra
 
     protected function getPackageProviders($app): array
     {
-        $this->registerTestPanel();
+        $this->registerTestPanels();
 
         return [
             FilamentServiceProvider::class,


### PR DESCRIPTION
This PR aims to solve an issue I encountered with this plugin with a mutli-panel Filament application. 

Debug report: https://flareapp.io/share/x5M4dJX7

The plugin would check if it was enabled during `registerRenderHooks` however, it end up globally attempting to render`@livewire('menu-logins')` even for panels where the plugin was not added.

I had to register an additional panel inside the test `MenuLoginsTest`. Let me know if you would rather a separate test case file for this issue.

