### PR TITLE
login button layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ In the `users` method you can define the users (note: the users must exist), the
 ]);
 ```
 
+In each Filament theme, ensure that the plugin Blade files are included in the `tailwind.config.js` to ensure proper CSS generation.
+
+```js
+{
+    content: [
+        //...
+        './vendor/dutchcodingcompany/filament-developer-logins/resources/**/*.blade.php',
+    ]
+}
+```
+
 ## Customization
 
 ### enabled()

--- a/resources/views/components/developer-logins.blade.php
+++ b/resources/views/components/developer-logins.blade.php
@@ -1,23 +1,21 @@
+<div class="flex flex-col gap-y-6">
+    <div class="relative flex items-center justify-center text-center">
+        <div class="absolute border-t border-gray-200 w-full h-px"></div>
+        <p class="inline-block relative bg-white text-sm p-2 rounded-full font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-100">
+            {{ __('filament-developer-logins::auth.login-as') }}
+        </p>
+    </div>
+
+    @if ($errors->has('developer-logins-failed'))
+        <div class="justify-center text-center">
+            <p class="fi-fo-field-wrp-error-message text-danger-600 dark:text-danger-400">
+                {{ $errors->first('developer-logins-failed') }}
+            </p>
+        </div>
+    @endif
+
+    <div class="flex flex-col gap-4">
 @foreach ($users as $label => $credentials)
-    @if ($loop->first)
-        <div class="flex flex-col gap-y-6">
-            <div class="relative flex items-center justify-center text-center">
-                <div class="absolute border-t border-gray-200 w-full h-px"></div>
-                <p class="inline-block relative bg-white text-sm p-2 rounded-full font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-100">
-                    {{ __('filament-developer-logins::auth.login-as') }}
-                </p>
-            </div>
-
-            @if ($errors->has('developer-logins-failed'))
-                <div class="justify-center text-center">
-                    <p class="fi-fo-field-wrp-error-message text-danger-600 dark:text-danger-400">
-                        {{ $errors->first('developer-logins-failed') }}
-                    </p>
-                </div>
-            @endif
-
-            <div class="grid grid-cols-2 gap-4">
-     @endif
         <form action="{{ route('filament-developer-logins.login-as') }}" method="POST">
             @csrf
 
@@ -28,8 +26,7 @@
                 {{ "$label ($credentials)" }}
             </x-filament::button>
         </form>
-    @if ($loop->first)
-            </div>
-        </div>
-    @endif
 @endforeach
+    </div>
+</div>
+


### PR DESCRIPTION
This PR adds instructions for including the plugin blade files into tailwinds config and fixes a layout issue I would come across randomly. 

I modified the layout for `developer-logins.blade.php` so that the error messages and wrapper are declared outside of the loop which previously would create them inside the `loop->first` check. I also switched the button container from a 2 col grid to a flex. Let me know if I overlooked the purpose of the `loop->first` check and the grid layout