### PR TITLE
Fix: Clear session password hash to resolve "Switch To" Button Error (Issue #15)

### DIFF
--- a/src/FilamentDevelopersLogin.php
+++ b/src/FilamentDevelopersLogin.php
@@ -19,6 +19,7 @@ class FilamentDevelopersLogin
 
         if ($panel->auth()->check()) {
             $panel->auth()->logout();
+
             session()->forget('password_hash_'.$panel->getAuthGuard());
         }
 

--- a/src/FilamentDevelopersLogin.php
+++ b/src/FilamentDevelopersLogin.php
@@ -19,6 +19,7 @@ class FilamentDevelopersLogin
 
         if ($panel->auth()->check()) {
             $panel->auth()->logout();
+            session()->forget('password_hash_'.$panel->getAuthGuard());
         }
 
         $model = (new ($plugin->getModelClass()))


### PR DESCRIPTION
### Summary
This pull request addresses issue [#15](https://github.com/DutchCodingCompany/filament-developer-logins/issues/15), where the "Switch To" button triggers an error due to an undefined route [login]. The root cause of the problem is related to a session handling issue, not an actual missing route.

### Details
The `AuthenticateSession` middleware checks for a session key `password_hash_{authGuard}` to validate the user's session. If this key is not set, it creates a new one. In this case, the key was not being cleared properly on logout, causing the session to retain stale data that led to the error.

This fix adds a line to clear the `password_hash_{authGuard}` session key during logout. This approach is similar to the logout implementation in `Orchestra\Workbench\Http\Controllers\WorkbenchController`, which also clears the session key on logout to prevent inconsistencies.

### Changes
- **FilamentDevelopersLogin.php**: Added `session()->forget('password_hash_'.$panel->getAuthGuard());` in the logout logic to ensure the session is properly reset.

### Testing
After applying this fix, I tested the functionality and confirmed that the error no longer occurs. The "Switch To" button now works as expected without triggering a route error.

Please let me know if you need any additional information or adjustments to this solution. Thank you!
