### PR TITLE
fix: redirect to current panel from menu login

### DIFF
--- a/src/Livewire/MenuLogins.php
+++ b/src/Livewire/MenuLogins.php
@@ -38,6 +38,6 @@ class MenuLogins extends Component
             abort(403);
         }
 
-        return FilamentDevelopersLogin::login(Filament::getPanel(), $this->plugin, $credentials);
+        return FilamentDevelopersLogin::login(Filament::getCurrentPanel(), $this->plugin, $credentials);
     }
 }


### PR DESCRIPTION
This PR fixes a bug. When switching user from Menu, the user used to get redirected to admin panel by default and i have fixed that by getting the current panel id.