### PR TITLE
feat: prioritize auth config for User model path resolution

### DIFF
--- a/src/FilamentDeveloperLoginsPlugin.php
+++ b/src/FilamentDeveloperLoginsPlugin.php
@@ -2,7 +2,6 @@
 
 namespace DutchCodingCompany\FilamentDeveloperLogins;
 
-use App\Models\User;
 use Closure;
 use DutchCodingCompany\FilamentDeveloperLogins\Exceptions\ImplementationException;
 use Filament\Contracts\Plugin;
@@ -15,6 +14,11 @@ use Illuminate\Contracts\Auth\Authenticatable;
 class FilamentDeveloperLoginsPlugin implements Plugin
 {
     use EvaluatesClosures, HasColumns;
+
+    /**
+     * @var class-string<\Illuminate\Database\Eloquent\Model&\Illuminate\Contracts\Auth\Authenticatable>
+     */
+    public string $modelClass = '';
 
     public Closure | bool $enabled = false;
 
@@ -31,10 +35,10 @@ class FilamentDeveloperLoginsPlugin implements Plugin
 
     public string $column = 'email';
 
-    /**
-     * @var class-string<\Illuminate\Database\Eloquent\Model&\Illuminate\Contracts\Auth\Authenticatable>
-     */
-    public string $modelClass = User::class;
+    public function __construct()
+    {
+        $this->modelClass = config('auth.providers.users.model') ?? \App\Models\User::class;
+    }
 
     public function getId(): string
     {


### PR DESCRIPTION
This PR improves the User model path configuration in FilamentDeveloperLogins plugin by properly utilizing Laravel's auth configuration system. The plugin now prioritizes the model path from Laravel's auth configuration while maintaining backward compatibility with the default path.

____

## Problem
Previously, the plugin was hardcoded to look for the User model in the default path (`\App\Models\User::class`), which caused issues when the User model was moved to a different location or when using a custom user model path.

## Changes
Modified the `modelClass` initialization in `FilamentDeveloperLoginsPlugin` to be more flexible and configurable