### PR TITLE
Allow showing the menu while disconnected

### DIFF
--- a/src/Livewire/MenuLogins.php
+++ b/src/Livewire/MenuLogins.php
@@ -27,9 +27,9 @@ class MenuLogins extends Component
         ]);
     }
 
-    protected function getCurrentUser(): string
+    protected function getCurrentUser(): ?string
     {
-        return Filament::auth()->user()->{$this->plugin->getColumn()};
+        return Filament::auth()->user()?->{$this->plugin->getColumn()};
     }
 
     public function loginAs(string $credentials): RedirectResponse | Redirector


### PR DESCRIPTION
Hi, 
Thanks for your work.

This PR allows showing the user switch menu on pages where users are not logged in.

(Previously "Can't read email on null")

Thanks.