### PR TITLE
Add option for a custom model callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ FilamentDeveloperLoginsPlugin::make()
     ->modelClass(Admin::class)
 ```
 
+### Override query
+
+Default the plugin will retrieve the user by searching the provided model using the specified column. If you want to implement your own logic to retrieve the user, you can use the `modelCallback()` method. 
+This method accepts a closure and provides the plugin and should return an instance of `Illuminate\Database\Eloquent\Builder`.
+
+Example:
+
+```php
+use DutchCodingCompany\FilamentDeveloperLogins\FilamentDeveloperLoginsPlugin;
+use Illuminate\Database\Eloquent\Builder;;
+
+FilamentDeveloperLoginsPlugin::make()
+    ->modelCallback(
+        fn (FilamentDeveloperLoginsPlugin $plugin, string $credentials): Builder 
+            => (new $plugin->getModelClass())
+                ->where($plugin->getColumn(), $credentials)
+                // Above is the default behavior. For example if you are using a global scope you can remove it here.
+                ->withoutGlobalScopes()
+    )
+```
+
 ### redirectTo()
 
 By default, the user will be redirected using the `Filament::getUrl()` method, which directs them to the dashboard. In the case of multi-tenancy, the user will also be redirected to the correct tenant. If you prefer to use a different url, you can utilize the redirectTo() method.

--- a/src/FilamentDevelopersLogin.php
+++ b/src/FilamentDevelopersLogin.php
@@ -25,9 +25,11 @@ class FilamentDevelopersLogin
         }
 
         /** @var ?\Illuminate\Contracts\Auth\Authenticatable $model */
-        $model = (new ($plugin->getModelClass()))
-            ->where($plugin->getColumn(), $credentials)
-            ->first();
+        $model = $plugin->getModelCallback($plugin, $credentials)->first();
+
+//        $model = (new ($plugin->getModelClass()))
+//            ->where($plugin->getColumn(), $credentials)
+//            ->first();
 
         if (! $model) {
             throw ValidationException::withMessages([


### PR DESCRIPTION
As discussed in https://github.com/DutchCodingCompany/filament-developer-logins/issues/27. 

This feature adds the option to override the default behavior of retrieving users from the database. For example, when using scopes that need to be removed when switching users.