### PR TITLE
Refactor redirect logic in FilamentDevelopersLogin

### DIFF
--- a/src/FilamentDevelopersLogin.php
+++ b/src/FilamentDevelopersLogin.php
@@ -51,6 +51,6 @@ class FilamentDevelopersLogin
         session()->regenerate();
 
         return redirect()
-            ->to(Redirect::getIntendedUrl() ?? $plugin->getRedirectTo() ?? $panel->getUrl());
+            ->intended($plugin->getRedirectTo() ?? $panel->getUrl());
     }
 }


### PR DESCRIPTION
Ensure that url.intended is deleted after redirecting to the intended url.

This is requried to avoid being redirected to a (possibly forbidden, if the permission depends on roles and therefore depends on the user) non-desired page.

When you access, say /admin/admin-restricted, while being logged out, then click on a button to log in as an admin, you'll be redirected to the correct page. If after logging in, you change user with the header button (selecting a non-admin user), you'll be redirected to the /admin/admin-restricted page, even if you navigated beforehand. This fixes it