### PR TITLE
Make enabled() require an explicit boolean paramete

### DIFF
--- a/src/FilamentDeveloperLoginsPlugin.php
+++ b/src/FilamentDeveloperLoginsPlugin.php
@@ -84,12 +84,13 @@ class FilamentDeveloperLoginsPlugin implements Plugin
         throw new ImplementationException('No panel found with filament-developer-logins plugin.');
     }
 
-    public function enabled(Closure | bool $value = true): static
+    public function enabled(Closure | bool $value): static
     {
         $this->enabled = $value;
 
         return $this;
     }
+
 
     public function getEnabled(): bool
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -55,7 +55,7 @@ class TestCase extends Orchestra
                 ])
                 ->plugins([
                     FilamentDeveloperLoginsPlugin::make()
-                        ->enabled()
+                        ->enabled(true)
                         ->users([
                             'Administrator' => 'developer@dutchcodingcompany.com',
                         ])


### PR DESCRIPTION
### What changed?

This PR updates the `enabled()` method to require an explicit boolean parameter instead of defaulting to `true`.

Previously, calling:

```php
FilamentDeveloperLoginsPlugin::make()->enabled();
